### PR TITLE
Add model for Conversation

### DIFF
--- a/app/models/conversation.rb
+++ b/app/models/conversation.rb
@@ -1,0 +1,6 @@
+class Conversation < ApplicationRecord
+  belongs_to :user
+  belongs_to :standup
+
+  validates :user, :standup, presence: true
+end

--- a/db/migrate/20160818023504_create_conversations.rb
+++ b/db/migrate/20160818023504_create_conversations.rb
@@ -1,0 +1,10 @@
+class CreateConversations < ActiveRecord::Migration[5.0]
+  def change
+    create_table :conversations do |t|
+      t.references :user, foreign_key: true
+      t.references :standup, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160818005806) do
+ActiveRecord::Schema.define(version: 20160818023504) do
+
+  create_table "conversations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
+    t.integer  "user_id"
+    t.integer  "standup_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["standup_id"], name: "index_conversations_on_standup_id", using: :btree
+    t.index ["user_id"], name: "index_conversations_on_user_id", using: :btree
+  end
 
   create_table "participations", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "user_id"
@@ -48,6 +57,8 @@ ActiveRecord::Schema.define(version: 20160818005806) do
     t.index ["email"], name: "index_users_on_email", using: :btree
   end
 
+  add_foreign_key "conversations", "standups"
+  add_foreign_key "conversations", "users"
   add_foreign_key "participations", "standups"
   add_foreign_key "participations", "users"
   add_foreign_key "questions", "standups"

--- a/spec/factories/conversations.rb
+++ b/spec/factories/conversations.rb
@@ -1,0 +1,6 @@
+FactoryGirl.define do
+  factory :conversation do
+    user factory: :user
+    standup factory: :standup
+  end
+end

--- a/spec/models/conversation_spec.rb
+++ b/spec/models/conversation_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe Conversation, type: :model do
+  let(:conversation) { FactoryGirl.create(:conversation) }
+  let(:user) { conversation.user }
+  let(:standup) { conversation.standup }
+
+  subject { conversation }
+
+  context "validations" do
+    subject { FactoryGirl.build(:conversation) }
+
+    it "is valid" do
+      expect(subject).to be_valid
+    end
+
+    it "requires a user" do
+      subject.user = nil
+      expect(subject).to_not be_valid
+    end
+
+    it "requires a standup" do
+      subject.standup = nil
+      expect(subject).to_not be_valid
+    end
+  end
+end


### PR DESCRIPTION
#1 @annieclaudecote

Add a `Conversation` model. Will model an interaction between a user in a chat for a given standup. Going to have questions and answers hanging off of it.
